### PR TITLE
Fix one test case

### DIFF
--- a/verification/tests.py
+++ b/verification/tests.py
@@ -54,7 +54,7 @@ TESTS = {
         ]),
     )),
     'Extra': list(make_extra_tests(
-        ('werewjackhvampirewitchnstree', 9),
+        ('werewjackhvampirewitchnstree', 8),
         ('zskelemummytonhosvampirenstein', 7),
         ('smwerewolfreneolfvampjackackhh', 12),
         ('mwzjackfvampireteinmbieenstegwitchf', 11),


### PR DESCRIPTION
    Maybe I am missing something, but I got a different number (lower) for one of the test cases.
    
    This test case 'werewjackhvampirewitchnstree' == 9 might be incorrect.
    Explanation:
```yaml
     1. Found a monster part (of 'vampire') 'vampire'  in 'werewjackhvampirewitchnstree'.
     2. Found a monster part (of 'werewolf') 'werew'   in 'werewjackh_______witchnstree'.
     3. Found a monster part (of 'witch') 'witch'      in '_____jackh_______witchnstree'.
     4. Found a monster part (of 'jack') 'jack'        in '_____jackh____________nstree'.
     5. Found a monster part (of 'frankenstein') 'nst' in '_________h____________nstree'.
     6. Found a monster part (of 'vampire') 're'       in '_________h_______________ree'.
     7. Found a monster part (of 'ghost') 'h'          in '_________h_________________e'.
     8. Found a monster part (of 'vampire') 'e'        in '___________________________e'.
```
